### PR TITLE
cleanup: use AWSCLIv2 without glibc

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -88,8 +88,8 @@ RUN curl -sSL -o vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}
     rm vault.zip && \
     vault --version
 
-COPY --from=builder /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=builder /aws-cli-bin/ /usr/local/bin/
+COPY --from=awsbuilder /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=awsbuilder /aws-cli-bin/ /usr/local/bin/
 
 RUN curl -sSL -o cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${TARGETARCH} && \
     install -o root -g root -m 0755 cosign /opt/aoepeople/bin/cosign && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,23 @@
+
+ARG ALPINE_VERSION=3.16
+FROM python:3.10.5-alpine${ALPINE_VERSION} as awsbuilder
+ARG AWS_CLI_VERSION=2.7.20
+RUN apk add --no-cache git unzip groff build-base libffi-dev cmake
+RUN git clone --single-branch --depth 1 -b ${AWS_CLI_VERSION} https://github.com/aws/aws-cli.git
+WORKDIR aws-cli
+RUN sed -i'' 's/PyInstaller.*/PyInstaller==5.2/g' requirements-build.txt
+RUN python -m venv venv
+RUN . venv/bin/activate
+RUN scripts/installers/make-exe
+RUN unzip -q dist/awscli-exe.zip
+RUN aws/install --bin-dir /aws-cli-bin
+RUN /aws-cli-bin/aws --version
+RUN rm -rf /usr/local/aws-cli/v2/current/dist/aws_completer /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index /usr/local/aws-cli/v2/current/dist/awscli/examples
+RUN find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete
+
 FROM gcr.io/kaniko-project/executor:debug as kaniko
 
-FROM alpine:3.16
+FROM alpine:${ALPINE_VERSION}
 LABEL maintainer "aoepeople <aoepeople@aoe.com>"
 ARG TARGETARCH
 
@@ -18,7 +35,6 @@ ARG KUBECTL_VERSION=1.23.3
 ARG TERRAFORM_VERSION=0.15.5
 ARG TERRAGRUNT_VERSION=0.36.1
 ARG VAULT_VERSION=1.7.3
-ARG GLIBC_VERSION=2.34-r0
 ARG COSIGN_VERSION=1.5.2
 
 RUN mkdir -p /opt/aoepeople/bin && \
@@ -72,37 +88,8 @@ RUN curl -sSL -o vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}
     rm vault.zip && \
     vault --version
 
-# see https://github.com/team-carepay/openjdk-docker/blob/main/alpine/Dockerfile#L26
-RUN apk add --no-cache --virtual binutils-pack \
-          binutils \
-      && \
-      curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \
-      curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
-      curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk && \
-      apk add --no-cache --virtual glibc-pack \
-          glibc-${GLIBC_VERSION}.apk \
-          glibc-bin-${GLIBC_VERSION}.apk \
-      && \
-      apk --no-cache del \
-          binutils-pack \
-      && \
-      rm glibc-${GLIBC_VERSION}.apk && \
-      rm glibc-bin-${GLIBC_VERSION}.apk && \
-      if [ "${TARGETARCH}" = "amd64" ] ; then \
-          curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
-        else \
-          curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
-        fi && \
-      unzip -q awscliv2.zip && \
-      aws/install && \
-      rm -rf \
-          awscliv2.zip \
-          aws \
-          /usr/local/aws-cli/v2/current/dist/aws_completer \
-          /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
-          /usr/local/aws-cli/v2/current/dist/awscli/examples \
-      && \
-      find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete;
+COPY --from=builder /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=builder /aws-cli-bin/ /usr/local/bin/
 
 RUN curl -sSL -o cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${TARGETARCH} && \
     install -o root -g root -m 0755 cosign /opt/aoepeople/bin/cosign && \


### PR DESCRIPTION
Seems that there's now a way to install awscliv2 without glibc -> https://stackoverflow.com/questions/60298619/awscli-version-2-on-alpine-linux ... let's see if that works.